### PR TITLE
Feat: Add local PDF file support to paper CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Two CLI tools in one repo: `paper` (read academic PDFs) and `search` (web + acad
 - **paper modules**: `cli.py`, `parser.py`, `fetcher.py`, `storage.py`, `renderer.py`, `models.py`, `highlighter.py`
 - **search modules**: `cli.py`, `config.py`, `models.py`, `renderer.py`, `backends/{google,semanticscholar,pubmed,browse}.py`
 - **Cache**: `~/.papers/<paper_id>/` (papers: `paper.pdf`, `parsed.json`, `metadata.json`, `highlights.json`, `paper_annotated.pdf`), `~/.papers/.env` (persistent API keys)
-- **Local PDFs**: Pass a file path (e.g., `./paper.pdf`) instead of an arxiv ID — reads directly, no download
+- **Local PDFs**: Pass a file path (e.g., `./paper.pdf`) instead of an arxiv ID — reads directly, no download. Cache uses `{stem}-{hash8}` IDs (SHA-256 of absolute path) to avoid collisions. Stale caches are detected via mtime comparison.
 - **Tests**: `pytest` — paper tests in `tests/` (124 tests), search tests in `tests/search/` (69 tests)
 - **Agent skills**: `.claude/skills/` — research-coordinator, deep-research, literature-review, fact-check
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ paper highlight remove <ref> <id>      # Remove a highlight by ID
 
 `<ref>` accepts: `2302.13971`, `arxiv.org/abs/2302.13971`, `arxiv.org/pdf/2302.13971`, or a **local PDF path** like `./paper.pdf`
 
-Arxiv papers are downloaded once and cached in `~/.papers/`. Local PDFs are read directly from disk.
+Arxiv papers are downloaded once and cached in `~/.papers/`. Local PDFs are read directly from disk — each gets a unique cache directory based on its absolute path (`{stem}-{hash8}`), so two different `paper.pdf` files in different directories won't collide. If you modify a local PDF after it's been parsed, the stale cache is automatically detected and re-parsed.
 
 ## `search` commands
 

--- a/src/paper/parser.py
+++ b/src/paper/parser.py
@@ -33,7 +33,7 @@ def parse_paper(arxiv_id: str, pdf_path: Path) -> Document:
 
     Uses cached result if available.
     """
-    if storage.has_parsed(arxiv_id):
+    if storage.has_parsed(arxiv_id) and not storage.is_local_cache_stale(arxiv_id):
         return Document.load(storage.parsed_path(arxiv_id))
 
     with fitz.open(pdf_path) as doc_fitz:
@@ -41,6 +41,14 @@ def parse_paper(arxiv_id: str, pdf_path: Path) -> Document:
 
     # Cache the parsed result
     document.save(storage.parsed_path(arxiv_id))
+
+    # Update mtime in metadata so the next cache-hit check passes
+    meta = storage.load_metadata(arxiv_id)
+    if meta and meta.get("source") == "local":
+        source_path = Path(meta["source_path"])
+        if source_path.is_file():
+            meta["source_mtime"] = source_path.stat().st_mtime
+            storage.save_metadata(arxiv_id, meta)
 
     # Update index with title
     if document.metadata.title:

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,9 +10,9 @@
 | `test_parser.py` | Heading detection heuristics, sentence splitting, fragment merging |
 | `test_cli.py` | CLI smoke tests (help output, flag presence, error handling) |
 | `test_links.py` | Citation detection, ref registry building, `goto` rendering |
-| `test_fetcher.py` | ArXiv ID resolution from various URL formats |
+| `test_fetcher.py` | ArXiv ID resolution, local PDF ID generation (`{stem}-{hash8}`), local metadata saving |
 | `test_highlighter.py` | Highlight search, coordinate conversion, CRUD, storage |
-| `test_storage.py` | Cache directory management, JSON corruption recovery |
+| `test_storage.py` | Cache directory management, JSON corruption recovery, local PDF cache staleness detection |
 | `test_integration.py` | End-to-end parsing of real papers (see below) |
 
 ### search tests (`tests/search/`)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,8 +1,11 @@
 """Tests for paper.fetcher — arxiv URL resolution and PDF fetching."""
 
+import hashlib
+
 import pytest
 
-from paper.fetcher import fetch_paper, resolve_arxiv_id
+from paper import storage
+from paper.fetcher import _local_paper_id, fetch_paper, resolve_arxiv_id
 
 
 class TestResolveArxivId:
@@ -37,21 +40,45 @@ class TestResolveArxivId:
         assert resolve_arxiv_id("2510.25744") == "2510.25744"
 
 
+class TestLocalPaperId:
+    def test_stem_included(self, tmp_path):
+        pid = _local_paper_id(tmp_path / "my_paper.pdf")
+        assert pid.startswith("my_paper-")
+
+    def test_different_paths_different_ids(self, tmp_path):
+        id1 = _local_paper_id(tmp_path / "dir1" / "paper.pdf")
+        id2 = _local_paper_id(tmp_path / "dir2" / "paper.pdf")
+        assert id1 != id2
+
+    def test_deterministic(self, tmp_path):
+        p = tmp_path / "paper.pdf"
+        assert _local_paper_id(p) == _local_paper_id(p)
+
+    def test_hash_length(self, tmp_path):
+        pid = _local_paper_id(tmp_path / "paper.pdf")
+        # Format: stem-hash8
+        parts = pid.rsplit("-", 1)
+        assert len(parts) == 2
+        assert len(parts[1]) == 8
+
+
 class TestFetchPaperLocal:
-    def test_local_pdf(self, tmp_path):
+    def test_local_pdf(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(storage, "PAPERS_DIR", tmp_path / ".papers")
         pdf = tmp_path / "my_paper.pdf"
         pdf.write_bytes(b"%PDF-1.4 fake")
         paper_id, path = fetch_paper(str(pdf))
-        assert paper_id == "my_paper"
+        assert paper_id.startswith("my_paper-")
         assert path == pdf.resolve()
 
     def test_local_pdf_tilde(self, tmp_path, monkeypatch):
         """Ensure ~ expansion works."""
+        monkeypatch.setattr(storage, "PAPERS_DIR", tmp_path / ".papers")
         pdf = tmp_path / "test.pdf"
         pdf.write_bytes(b"%PDF-1.4 fake")
         monkeypatch.setenv("HOME", str(tmp_path))
         paper_id, path = fetch_paper("~/test.pdf")
-        assert paper_id == "test"
+        assert paper_id.startswith("test-")
         assert path == pdf.resolve()
 
     def test_local_pdf_not_found(self):
@@ -65,3 +92,14 @@ class TestFetchPaperLocal:
         txt.write_text("not a pdf")
         with pytest.raises(ValueError, match="Could not parse reference"):
             fetch_paper(str(txt))
+
+    def test_saves_local_metadata(self, tmp_path, monkeypatch):
+        """fetch_paper should write local metadata with source/path/mtime."""
+        monkeypatch.setattr(storage, "PAPERS_DIR", tmp_path / ".papers")
+        pdf = tmp_path / "meta_test.pdf"
+        pdf.write_bytes(b"%PDF-1.4 fake")
+        paper_id, _ = fetch_paper(str(pdf))
+        meta = storage.load_metadata(paper_id)
+        assert meta["source"] == "local"
+        assert meta["source_path"] == str(pdf.resolve())
+        assert "source_mtime" in meta


### PR DESCRIPTION
Allow passing a local PDF path (e.g., ./paper.pdf) as a reference instead of only arxiv IDs. Skips download for local files and avoids generating bogus arxiv URLs in metadata for non-arxiv papers.