### PR TITLE
Add PyPI publish workflow (GitHub Actions)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` that triggers on `v*` tag pushes
- Builds with `uv build`, publishes via PyPI trusted publisher (OIDC — no API token needed)

## Setup required
Before tagging `v0.1.0`, register the trusted publisher on PyPI:
1. Go to https://pypi.org/manage/project/agent-papers-cli/settings/publishing/
2. Add a new publisher: GitHub, repo `collaborative-deep-research/agent-papers-cli`, workflow `publish.yml`, environment (leave blank)

## Release flow
```bash
# bump version in pyproject.toml + src/paper/__init__.py
git commit -am "Release v0.1.0"
git tag v0.1.0
git push origin main --tags
# → GH Actions builds and publishes automatically
```
