### PR TITLE
Support configurable cache directory via PAPERS_CACHE_DIR

### DIFF
--- a/src/paper/layout.py
+++ b/src/paper/layout.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 import fitz  # PyMuPDF
 
 from paper.models import Box, LayoutElement
-from paper.storage import layout_path, has_layout
+from paper.storage import PAPERS_DIR, layout_path, has_layout
 
 if TYPE_CHECKING:
     from doclayout_yolo import YOLOv10
@@ -56,7 +56,7 @@ _model_instance: YOLOv10 | None = None
 # ------------------------------------------------------------------
 
 def _models_dir() -> Path:
-    d = Path.home() / ".papers" / ".models"
+    d = PAPERS_DIR / ".models"
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/src/paper/storage.py
+++ b/src/paper/storage.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-PAPERS_DIR = Path.home() / ".papers"
+PAPERS_DIR = Path(os.environ.get("PAPERS_CACHE_DIR", Path.home() / ".papers"))
 
 
 def _sanitize_paper_id(paper_id: str) -> str:

--- a/src/search/config.py
+++ b/src/search/config.py
@@ -19,12 +19,12 @@ Required keys per command:
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 from dotenv import load_dotenv
 
+from paper.storage import PAPERS_DIR
+
 # Persistent config location (shared with paper CLI)
-PAPERS_DIR = Path.home() / ".papers"
 PERSISTENT_ENV = PAPERS_DIR / ".env"
 
 # Load in priority order (earlier loads win because dotenv doesn't overwrite existing)


### PR DESCRIPTION
## Summary
- Make the `~/.papers` cache directory configurable via `PAPERS_CACHE_DIR` environment variable (defaults to `~/.papers` when unset)
- Consolidate duplicate `PAPERS_DIR` definition — `search/config.py` now imports from `paper/storage.py`
- Fix hardcoded `~/.papers/.models` path in `layout.py` to use the shared `PAPERS_DIR`

## Motivation
On Vercel (and similar serverless platforms), the home directory is read-only. Setting `PAPERS_CACHE_DIR=/tmp/.papers` allows the library to work in these environments.

## Test plan
- [x] All 275 existing tests pass
- [ ] Verify `PAPERS_CACHE_DIR=/tmp/test-papers paper read <ref>` caches to the custom path
- [ ] Verify default behavior unchanged when env var is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)